### PR TITLE
Add Next.js Cozypolls prototype

### DIFF
--- a/cozypolls/.gitignore
+++ b/cozypolls/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+out

--- a/cozypolls/README.md
+++ b/cozypolls/README.md
@@ -1,0 +1,12 @@
+# Cozypolls
+
+This is a minimal Next.js implementation of the "Cozypolls" futuristic GenZ mobile polling app interface. It demonstrates the design using Apple's UI philosophy with light and dark themes.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+The main page is located at `/` and includes a theme toggle on the floating action button.

--- a/cozypolls/app/globals.css
+++ b/cozypolls/app/globals.css
@@ -1,0 +1,130 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+
+:root {
+  --font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Helvetica Neue', sans-serif;
+  --accent-light: linear-gradient(90deg, #A1FFCE, #D0FFC2);
+  --accent-dark: #00F4E7;
+}
+
+html, body {
+  padding: 0;
+  margin: 0;
+  font-family: var(--font-family);
+  letter-spacing: -0.01em;
+}
+
+.theme-light {
+  background: #FAFAF6;
+  color: #2B2B2B;
+}
+.theme-dark {
+  background: #0C111D;
+  color: #F8FAFC;
+}
+
+.top-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+}
+
+.segments button {
+  background: none;
+  border: none;
+  padding: 0.25rem 0.5rem;
+  font-weight: 600;
+  opacity: 0.6;
+}
+
+.segments .active {
+  opacity: 1;
+  border-bottom: 2px solid #00F4E7;
+}
+
+.poll-card {
+  margin: 2rem 1rem;
+  padding: 2rem;
+  border-radius: 1rem;
+  background: rgba(255,255,255,0.2);
+  backdrop-filter: blur(20px);
+  text-align: center;
+}
+
+.vote-buttons button {
+  font-size: 2rem;
+  margin: 0 0.5rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.results {
+  margin-top: 1rem;
+  font-weight: 500;
+}
+
+.fab {
+  position: fixed;
+  bottom: 4.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--accent-light);
+  border: none;
+  border-radius: 50%;
+  width: 60px;
+  height: 60px;
+  color: #000;
+  font-size: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+  cursor: pointer;
+}
+
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-around;
+  padding: 0.5rem 0;
+  background: rgba(255,255,255,0.3);
+  backdrop-filter: blur(10px);
+}
+
+.bottom-nav button {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+}
+
+.bottom-nav .create {
+  font-size: 2rem;
+}
+
+.notify {
+  position: relative;
+}
+
+.badge {
+  position: absolute;
+  top: -4px;
+  right: -6px;
+  background: red;
+  color: white;
+  border-radius: 50%;
+  padding: 2px 4px;
+  font-size: 0.6rem;
+}
+
+.theme-dark .fab {
+  background: var(--accent-dark);
+  color: #0C111D;
+}
+
+.theme-dark .bottom-nav {
+  background: rgba(0,0,0,0.3);
+}

--- a/cozypolls/app/layout.tsx
+++ b/cozypolls/app/layout.tsx
@@ -1,0 +1,16 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Cozypolls',
+  description: 'GenZ mobile polling app interface built with Next.js',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/cozypolls/app/page.tsx
+++ b/cozypolls/app/page.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { useState } from 'react';
+
+export default function Home() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const toggleTheme = () => setTheme(theme === 'light' ? 'dark' : 'light');
+
+  return (
+    <div className={`theme-${theme}`}> 
+      <header className="top-nav">
+        <div className="logo">😊</div>
+        <div className="segments">
+          <button className="active">For You</button>
+          <button>Trending</button>
+          <button>Friends</button>
+        </div>
+        <div className="notify">🔔<span className="badge">1</span></div>
+      </header>
+
+      <section className="poll-card">
+        <h1>Is pineapple on pizza awesome?</h1>
+        <div className="vote-buttons">
+          <button>🍍</button>
+          <button>🍕</button>
+        </div>
+        <div className="results">You vibe with 63%</div>
+      </section>
+
+      <button className="fab" onClick={toggleTheme}>➕</button>
+
+      <nav className="bottom-nav">
+        <button>🏠</button>
+        <button>🔍</button>
+        <button className="create">➕</button>
+        <button>🎖️</button>
+        <button>👤</button>
+      </nav>
+    </div>
+  );
+}

--- a/cozypolls/next-env.d.ts
+++ b/cozypolls/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/cozypolls/next.config.js
+++ b/cozypolls/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/cozypolls/package.json
+++ b/cozypolls/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "cozypolls",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.2.2"
+  }
+}

--- a/cozypolls/tsconfig.json
+++ b/cozypolls/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add `cozypolls` folder with a minimal Next.js project
- implement layout and page using light/dark themes and Gen Z inspired design
- include global styles with Apple-like typography and colors

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d49ae848c83289bed5864db4ad4a5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a minimal GenZ-inspired mobile polling app interface with light and dark theme support.
  * Added a theme toggle via a floating action button.
  * Included a sample poll card, segmented controls, notification badge, and a bottom navigation bar.

* **Style**
  * Implemented global styles for layout, theming, navigation, poll cards, and buttons.

* **Documentation**
  * Added a README with setup instructions and feature overview.

* **Chores**
  * Added configuration files for Next.js, TypeScript, and project dependencies.
  * Set up `.gitignore` to exclude build and dependency directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->